### PR TITLE
Fix case where file ending in comment won't run

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ module.exports = function (source, inputSourceMap) {
      * @returns {string}
      */
     function createPostfix(exportVarTree, exportedVars, config) {
-        postfix = ';';
+        postfix = ';\n';
         Object.keys(exportVarTree).forEach(function (rootVar) {
             var jsonObj;
             enrichExport(exportVarTree[rootVar], rootVar);


### PR DESCRIPTION
Found an annoying bug where a line ending with a line comment would not compile because comment gets extended into exports line.

Example

```
//comment on last line
```

Gets transformed to

```
//comment on last line;exports.foo={"bar":foo.bar};exports.default=foo.bar;exports.__esModule=true;
```
